### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ jdk:
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 #script: mvn test
 script: mvn -DskipTests=true clean package
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.